### PR TITLE
[FIX] DeleteImage helper text.

### DIFF
--- a/zunclient/osc/v1/images.py
+++ b/zunclient/osc/v1/images.py
@@ -165,7 +165,7 @@ class DeleteImage(command.Command):
         parser.add_argument(
             'uuid',
             metavar='<uuid>',
-            help='UUID of image to describe')
+            help='UUID of image to delete')
         return parser
 
     def take_action(self, parsed_args):


### PR DESCRIPTION
Hello,

I was just watching a course about Zun and noticed that the cli helper text for the delete command was mispelled probably due to copy/paste.

Hope that it will be my first contribution to OpenStack projects.